### PR TITLE
Support for whitespace and other diagram types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
+venv2/
+venv3/
 build/
 develop-eggs/
 dist/

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,20 @@ In your markdown text you can define the block
   }
 
 
+Testing
+-------
+
+
+.. code-block::
+
+  $ pip install coverage
+  $ python setup.py test
+
+
 MkDocs Integration
 ------------------
+
+In your mkdocs.yml add this to markdown_extensions.
 
 .. code-block::
 

--- a/markdown_blockdiag/parser.py
+++ b/markdown_blockdiag/parser.py
@@ -10,6 +10,7 @@ from markdown_blockdiag.utils import draw_blockdiag, DIAG_MODULES
 class BlockdiagProcessor(BlockProcessor):
 
     RE = re.compile(r"""
+        ^
         (?P<diagtype>{})
         \s+
         \{{
@@ -18,21 +19,22 @@ class BlockdiagProcessor(BlockProcessor):
     def __init__(self, parser, extension):
         super(BlockdiagProcessor, self).__init__(parser)
         self.extension = extension
-        self.is_block_closed = True
 
     def test(self, parent, block):
-        is_initial_block = bool(self.RE.match(block))
-        if is_initial_block:
-            self.is_block_closed = False
-
-        if not self.is_block_closed:
-            self.is_block_closed = block.strip().endswith("}")
-
-        return is_initial_block or not self.is_block_closed
+        return bool(self.RE.match(block))
 
     def run(self, parent, blocks):
-        raw_block = "\n".join(blocks)
-        del blocks[:]
+        diag_blocks = []
+
+        for block in blocks:
+            block = block.strip()
+            diag_blocks.append(block)
+            if block.endswith("}"):
+                break
+
+        raw_block = "\n".join(diag_blocks)
+        del blocks[:len(diag_blocks)]
+
         font_path = self.extension.getConfig('fontpath')
         output_fmt = self.extension.getConfig('format')
         diagram = draw_blockdiag(raw_block, output_fmt=output_fmt, font_path=font_path)

--- a/markdown_blockdiag/parser.py
+++ b/markdown_blockdiag/parser.py
@@ -4,22 +4,35 @@ import base64
 
 from markdown.blockprocessors import BlockProcessor
 from markdown.util import etree
-from markdown_blockdiag.utils import draw_blockdiag
+from markdown_blockdiag.utils import draw_blockdiag, DIAG_MODULES
 
 
 class BlockdiagProcessor(BlockProcessor):
 
-    RE = re.compile('blockdiag\s+\{')
+    RE = re.compile(r"""
+        (?P<diagtype>{})
+        \s+
+        \{{
+    """.format("|".join(DIAG_MODULES.keys())), re.VERBOSE)
 
     def __init__(self, parser, extension):
         super(BlockdiagProcessor, self).__init__(parser)
         self.extension = extension
+        self.is_block_closed = True
 
     def test(self, parent, block):
-        return bool(self.RE.match(block))
+        is_initial_block = bool(self.RE.match(block))
+        if is_initial_block:
+            self.is_block_closed = False
+
+        if not self.is_block_closed:
+            self.is_block_closed = block.strip().endswith("}")
+
+        return is_initial_block or not self.is_block_closed
 
     def run(self, parent, blocks):
-        raw_block = blocks.pop(0)
+        raw_block = "\n".join(blocks)
+        del blocks[:]
         font_path = self.extension.getConfig('fontpath')
         output_fmt = self.extension.getConfig('format')
         diagram = draw_blockdiag(raw_block, output_fmt=output_fmt, font_path=font_path)

--- a/markdown_blockdiag/utils.py
+++ b/markdown_blockdiag/utils.py
@@ -1,10 +1,24 @@
 from __future__ import absolute_import, unicode_literals
 
-from blockdiag import parser, builder, drawer
+from nwdiag import parser as nw_parser, builder as nw_builder, drawer as nw_drawer
+from seqdiag import parser as seq_parser, builder as seq_builder, drawer as seq_drawer
+from actdiag import parser as act_parser, builder as act_builder, drawer as act_drawer
+from blockdiag import parser as block_parser, builder as block_builder, drawer as block_drawer
+
 from blockdiag.utils.fontmap import FontMap
 
 
+DIAG_MODULES = {
+    'nwdiag'   : (nw_parser, nw_builder, nw_drawer),
+    'seqdiag'  : (seq_parser, seq_builder, seq_drawer),
+    'actdiag'  : (act_parser, act_builder, act_drawer),
+    'blockdiag': (block_parser, block_builder, block_drawer),
+}
+
+
 def draw_blockdiag(content, filename=None, font_path=None, output_fmt='png'):
+    diag_type, content = content.split(" ", 1)
+    parser, builder, drawer = DIAG_MODULES[diag_type.strip()]
     tree = parser.parse_string(content)
     diagram = builder.ScreenNodeBuilder.build(tree)
 

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,17 @@ from setuptools import setup, find_packages
 
 setup(
     name='markdown-blockdiag',
-    version='0.3.0',
+    version='0.4.0',
     packages=find_packages(),
     url='https://github.com/gisce/markdown-blockdiag',
     license='MIT',
-    install_requires=['Markdown', 'blockdiag'],
+    install_requires=[
+        'Markdown',
+        'blockdiag',
+        'seqdiag',
+        'actdiag',
+        'nwdiag',
+    ],
     author='GISCE-TI, S.L.',
     author_email='devel@gisce.net',
     test_suite="tests",

--- a/tests/test_blockdiag.py
+++ b/tests/test_blockdiag.py
@@ -10,15 +10,41 @@ from markdown_blockdiag.parser import BlockdiagProcessor
 from markdown_blockdiag.utils import draw_blockdiag
 
 
-def join_text(lines):
-    return '\n'.join(lines)
+BASIC_DIAG_TXT = r"""
+blockdiag {
+    A -> B -> C;
+}
+""".strip()
 
 
-TEST_DIAG_TXT = join_text([
-    "blockdiag {",
-    "    A -> B -> C;",
-    "}"
-])
+EXTENDED_DIAG_TXT = r"""
+blockdiag {
+    A [label = "label test A"];
+    B [label = "label test B"];
+    C [label = "label test C"];
+
+    A -> B -> C  [label = tag];    // comment
+}
+""".strip()
+
+
+SEQ_DIAG_TXT = r"""
+seqdiag {
+    // edge label
+    A -> B [label = "call"];
+    A <- B [label = "return"];
+
+    // diagonal edge
+    A -> B [diagonal, label = "diagonal edge"];
+    A <- B [diagonal, label = "return diagonal edge"];
+
+    // color of edge
+    A -> B [label = "colored label", color = red];
+
+    // failed edge
+    A -> B [label = "failed edge", failed];
+}
+""".strip()
 
 
 class BlockdiagTest(unittest.TestCase):
@@ -26,16 +52,16 @@ class BlockdiagTest(unittest.TestCase):
     """
 
     def test_run(self):
-        self.assertTrue(BlockdiagProcessor.RE.match(TEST_DIAG_TXT))
+        self.assertTrue(BlockdiagProcessor.RE.match(BASIC_DIAG_TXT))
 
     def test_basic_blockdiag(self):
-        draw = draw_blockdiag(TEST_DIAG_TXT)
+        draw = draw_blockdiag(BASIC_DIAG_TXT)
 
         expected = '<p><img src="data:image/png;base64,{0}" /></p>'.format(
             base64.b64encode(draw)
         )
         result = markdown(
-            TEST_DIAG_TXT,
+            BASIC_DIAG_TXT,
             extensions=['markdown_blockdiag'],
         )
 
@@ -43,14 +69,38 @@ class BlockdiagTest(unittest.TestCase):
 
     def test_svg_blockdiag(self):
         self.maxDiff = None
-        draw = draw_blockdiag(TEST_DIAG_TXT, output_fmt='svg')
+        draw = draw_blockdiag(BASIC_DIAG_TXT, output_fmt='svg')
 
         expected = '<p><img src="data:image/svg+xml;utf8,{0}" /></p>'.format(draw)
         result = markdown(
-            TEST_DIAG_TXT,
+            BASIC_DIAG_TXT,
             extensions=['markdown_blockdiag'],
             extension_configs={'markdown_blockdiag': {'format': 'svg'}}
         )
         result = unescape(result).replace('&quot;', '\"')
 
+        self.assertEqual(expected, result)
+
+    def test_label_blockdiag(self):
+        draw = draw_blockdiag(EXTENDED_DIAG_TXT)
+
+        expected = '<p><img src="data:image/png;base64,{0}" /></p>'.format(
+            base64.b64encode(draw)
+        )
+        result = markdown(
+            EXTENDED_DIAG_TXT,
+            extensions=['markdown_blockdiag'],
+        )
+        self.assertEqual(expected, result)
+
+    def test_seqdiag(self):
+        draw = draw_blockdiag(SEQ_DIAG_TXT)
+
+        expected = '<p><img src="data:image/png;base64,{0}" /></p>'.format(
+            base64.b64encode(draw)
+        )
+        result = markdown(
+            SEQ_DIAG_TXT,
+            extensions=['markdown_blockdiag'],
+        )
         self.assertEqual(expected, result)

--- a/tests/test_blockdiag.py
+++ b/tests/test_blockdiag.py
@@ -47,6 +47,21 @@ seqdiag {
 """.strip()
 
 
+MARKDOWN_DOC = r"""
+# Title
+
+paragraph
+
+{diagram}
+
+paragraph
+
+{diagram}
+
+paragraph
+"""
+
+
 class BlockdiagTest(unittest.TestCase):
     """Testing blockdiag extension
     """
@@ -104,3 +119,20 @@ class BlockdiagTest(unittest.TestCase):
             extensions=['markdown_blockdiag'],
         )
         self.assertEqual(expected, result)
+
+    def test_markdown(self):
+        draw = draw_blockdiag(EXTENDED_DIAG_TXT)
+
+        expected = '<p><img src="data:image/png;base64,{0}" /></p>'.format(
+            base64.b64encode(draw)
+        )
+
+        marcdown_doc = MARKDOWN_DOC.format(diagram=EXTENDED_DIAG_TXT)
+        result = markdown(
+            marcdown_doc,
+            extensions=['markdown_blockdiag'],
+        )
+
+        self.assertTrue("Title" in result)
+        self.assertEqual(2, result.count(expected))
+        self.assertEqual(3, result.count("paragraph"))


### PR DESCRIPTION
This PR adds support for the nwdiag, seqdiag and actdiag modules and also allows empty lines within a diagram. I bumped the version number because new dependencies were added.