### PR TITLE
Specify ASCII encoding for base64 encoded PNG images.

### DIFF
--- a/markdown_blockdiag/parser.py
+++ b/markdown_blockdiag/parser.py
@@ -40,7 +40,7 @@ class BlockdiagProcessor(BlockProcessor):
         diagram = draw_blockdiag(raw_block, output_fmt=output_fmt, font_path=font_path)
         if output_fmt == 'png':
             src_data = 'data:image/png;base64,{0}'.format(
-                base64.b64encode(diagram)
+                base64.b64encode(diagram).decode('ascii')
             )
         else:
             src_data = 'data:image/svg+xml;utf8,{0}'.format(diagram)


### PR DESCRIPTION
Without this, Python 3 will use the byte literal format, so you end
up with "data:image/png;base64,b'iVBO..." which won't render.