### PR TITLE
Fix compatibility with Markdown>=3.4.0

### DIFF
--- a/markdown_blockdiag/parser.py
+++ b/markdown_blockdiag/parser.py
@@ -3,8 +3,8 @@ import re
 import base64
 
 from markdown.blockprocessors import BlockProcessor
-from markdown.util import etree
 from markdown_blockdiag.utils import draw_blockdiag, DIAG_MODULES
+from xml.etree import ElementTree
 
 # Python 3 version
 try:
@@ -53,6 +53,6 @@ class BlockdiagProcessor(BlockProcessor):
         else:
             src_data = 'data:image/svg+xml;charset=utf-8,{0}'.format(url_quote(diagram))
 
-        p = etree.SubElement(parent, 'p')
-        img = etree.SubElement(p, 'img')
+        p = ElementTree.SubElement(parent, 'p')
+        img = ElementTree.SubElement(p, 'img')
         img.attrib['src'] = src_data


### PR DESCRIPTION
> Various objects were deprecated in version 3.0
> Any of those object have been removed from the codebase in version 3.4 and will now raise errors.

https://github.com/Python-Markdown/markdown/blob/a767b2daaad78ba32d45a4f1dabb7c5e218f030a/docs/change_log/release-3.4.md#previously-deprecated-objects-have-been-removed