### PR TITLE
[WIP] Trying to fix the plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .Python
 env/
 venv/
+.venv/
 venv2/
 venv3/
 build/
@@ -24,6 +25,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/markdown_blockdiag/extension.py
+++ b/markdown_blockdiag/extension.py
@@ -12,7 +12,7 @@ class BlockdiagExtension(Extension):
         }
         super(BlockdiagExtension, self).__init__(**kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.parser.blockprocessors.add(
             'blockdiag', BlockdiagProcessor(md.parser, self), '>indent'
         )

--- a/markdown_blockdiag/extension.py
+++ b/markdown_blockdiag/extension.py
@@ -13,7 +13,7 @@ class BlockdiagExtension(Extension):
         super(BlockdiagExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md):
-        md.parser.blockprocessors.add(
+        md.parser.blockprocessors.register(
             'blockdiag', BlockdiagProcessor(md.parser, self), '>indent'
         )
         md.registerExtension(self)

--- a/markdown_blockdiag/parser.py
+++ b/markdown_blockdiag/parser.py
@@ -3,7 +3,7 @@ import re
 import base64
 
 from markdown.blockprocessors import BlockProcessor
-from markdown.util import etree
+import xml.etree.ElementTree as etree
 from markdown_blockdiag.utils import draw_blockdiag, DIAG_MODULES
 
 # Python 3 version


### PR DESCRIPTION
Hi,

Setting up a MkDocs project with Material for MkDocs it would be nice to enjoy blockdiag goodness... Sadly, it seems that the plugin needs a bit of love to work.

I've given a try at resolving the issues one after the other, but sadly, my skills abandoned me after two steps.

Here are the messages I'm getting

```
$ mkdocs -v --color serve
DEBUG   -  Loading configuration file: /home/tarax/GDrive/Sources/devu/fastapi-k8s/mkdocs.yml
DEBUG   -  Loaded theme configuration for 'material' from
           '/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/material/templates/mkdocs_theme.yml':
           {'language': 'en', 'direction': None, 'features': [], 'font': {'text': 'Roboto', 'code': 'Roboto Mono'}, 'icon':
           None, 'favicon': 'assets/images/favicon.png', 'static_templates': ['404.html']}
INFO    -  DeprecationWarning: pkg_resources is deprecated as an API. See
           https://setuptools.pypa.io/en/latest/pkg_resources.html
             File
           "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/blockdiag/noderenderer/__init__.py",
           line 18, in <module>
               import pkg_resources
             File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/pkg_resources/__init__.py",
           line 118, in <module>
               warnings.warn(
DEBUG   -  Config value 'config_file_path' = '/home/tarax/GDrive/Sources/devu/fastapi-k8s/mkdocs.yml'
DEBUG   -  Config value 'site_name' = 'DevOps-Boot: FastAPI-Traefik-K8s'
[...]
ERROR   -  Error reading page 'index.md': '<' not supported between instances of 'int' and 'str'
Traceback (most recent call last):
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/mkdocs/__main__.py", line 270, in serve_command
    serve.serve(**kwargs)
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/mkdocs/commands/serve.py", line 86, in serve
    builder(config)
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/mkdocs/commands/serve.py", line 67, in builder
    build(config, live_server=None if is_clean else server, dirty=is_dirty)
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/mkdocs/commands/build.py", line 322, in build
    _populate_page(file.page, config, files, dirty)
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/mkdocs/commands/build.py", line 175, in _populate_page
    page.render(config, files)
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/mkdocs/structure/pages.py", line 271, in render
    self.content = md.convert(self.markdown)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/markdown/core.py", line 357, in convert
    root = self.parser.parseDocument(self.lines).getroot()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/markdown/blockparser.py", line 117, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/markdown/blockparser.py", line 136, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/markdown/blockparser.py", line 156, in parseBlocks
    for processor in self.blockprocessors:
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/markdown/util.py", line 316, in __iter__
    self._sort()
  File "/home/tarax/GDrive/Sources/devu/fastapi-k8s/.venv/lib/python3.11/site-packages/markdown/util.py", line 398, in _sort
    self._priority.sort(key=lambda item: item.priority, reverse=True)
TypeError: '<' not supported between instances of 'int' and 'str'
```

I'm stuck there, unable that I am to interpret the error message and find where the error should be chased in the code.

Thanks in advance for your help and support

TY
J